### PR TITLE
Add systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ you can control changes in web pages and get a notification on your android phon
 <p align="center">
   <img src= "./media/Notification_example.jpg" width="144px" height="256px">
 
-## Dependencies installation
-```bash
-$ pip install -r requirements.txt
-```
+## Installation
+
+If not already present install `sed`; then run `install.sh`.
 
 ## Usage
-  To start just run: `python3 gui.py`
+- To start the graphical interface just run: `cwp`
+- To use the command line interface run `cwp-cli` (all available commands can be listed with `-h`)
+
   
 ## Gui
 
@@ -27,16 +28,6 @@ $ pip install -r requirements.txt
   - Notification  -> check if you whant to have the notification on the phone
   
   - Slider        -> inspection period (minutes)
-
-## Command line 
-
-You can also choose to start a daemon running in the background with 
-
-```
-$ python cwpd.py
-```
-
-and contact it through `cwp-cli.py` (all available command can be listed with `-h`)
 
 ## Development 
 

--- a/cwp_cli.py
+++ b/cwp_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from src.dbus import *
 from src import notification as notifications_module
 import pydbus

--- a/cwpd.py
+++ b/cwpd.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pydbus
 import logging
 import sys

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [[ -z $(which sed) ]] ; then
+	echo "Please install sed before installing"
+	exit 1
+fi
+
+current_dir=$(pwd)
+
+# link commands to be available with PATH
+sudo ln -s "${current_dir}"/cwp_cli.py /usr/local/bin/cwp-cli
+sudo ln -s "${current_dir}"/cwpd.py /usr/local/bin/cwpd
+sudo ln -s "${current_dir}"/gui.py /usr/local/bin/cwp
+
+# install dependencies
+pip install --user -r requirements.txt
+
+# activate and launch user service
+sed -i "s|__CWPD_LOC__|${current_dir}|" service/cwpd.service
+systemctl enable --user "${current_dir}"/service/cwpd.service
+systemctl start --user cwpd.service
+

--- a/service/cwpd.service
+++ b/service/cwpd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=The ChangesInWebPages daemon
+Documentation="https://github.com/Monti03/ChangesInWebPages"
+After=default.target
+
+[Service]
+Type=dbus
+BusName=org.github.changesinwebpages
+ExecStart=__CWPD_LOC__/cwpd.py
+WorkingDirectory=__CWPD_LOC__
+RestartSec=100
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Add `systemd` unit file in order to launch automatically a background service to monitor pages and handle notications (previously the daemon was started manually with `python3 cwpd.py`)